### PR TITLE
[Feat/#24] 스탬프 상세 뷰 데이터 연동 및 UX/UI 개선

### DIFF
--- a/Pollector/App/PollectorApp.swift
+++ b/Pollector/App/PollectorApp.swift
@@ -31,7 +31,8 @@ struct PollectorApp: App {
             StampListModel.self,
             Places.self,
             PlacesPhoto.self,
-            StampCompletionModel.self
+            StampCompletionModel.self,
+            StampCompletionPhoto.self
         ])
     }
 }

--- a/Pollector/App/PollectorApp.swift
+++ b/Pollector/App/PollectorApp.swift
@@ -1,6 +1,6 @@
 //
-//  pohangBuddyApp.swift
-//  pohangBuddy
+//  PollectorApp.swift
+//  Pollector
 //
 //  Created by 이은지 on 3/27/26.
 //
@@ -10,7 +10,7 @@ import SwiftData
 import GooglePlacesSwift
 
 @main
-struct pohangBuddyApp: App {
+struct PollectorApp: App {
     
     init() {
         guard

--- a/Pollector/Global/Components/ActionButton.swift
+++ b/Pollector/Global/Components/ActionButton.swift
@@ -10,7 +10,23 @@ import SwiftUI
 struct ActionButton: View {
     let title: String
     let imageName: String
+    var backgroundColor: Color = .neutral4
+    var isDisabled: Bool = false
     let action: () -> Void
+
+    init(
+        title: String,
+        imageName: String,
+        backgroundColor: Color = .neutral4,
+        isDisabled: Bool = false,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.imageName = imageName
+        self.backgroundColor = backgroundColor
+        self.isDisabled = isDisabled
+        self.action = action
+    }
 
     var body: some View {
         Button(action: action) {
@@ -28,10 +44,12 @@ struct ActionButton: View {
             .frame(maxWidth: .infinity, minHeight: 56)
             .background(
                 RoundedRectangle(cornerRadius: 24)
-                    .fill(.neutral4)
+                    .fill(backgroundColor)
             )
-            .shadow(color: Color.blue.opacity(0.3), radius: 8, y: 4)
+            .shadow(color: Color.black.opacity(0.3), radius: 8, y: 4)
         }
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.9 : 1)
         .buttonStyle(.plain)
     }
 }

--- a/Pollector/Global/Components/ActionButton.swift
+++ b/Pollector/Global/Components/ActionButton.swift
@@ -18,7 +18,7 @@ struct ActionButton: View {
                 Text(title)
                     .font(.head3)
             } icon: {
-                Image(imageName)
+                Image(systemName: imageName)
                     .renderingMode(.template)
                     .resizable()
                     .scaledToFit()
@@ -28,7 +28,7 @@ struct ActionButton: View {
             .frame(maxWidth: .infinity, minHeight: 56)
             .background(
                 RoundedRectangle(cornerRadius: 24)
-                    .fill(.neutral3)
+                    .fill(.neutral4)
             )
             .shadow(color: Color.blue.opacity(0.3), radius: 8, y: 4)
         }

--- a/Pollector/Global/Components/ActionButton.swift
+++ b/Pollector/Global/Components/ActionButton.swift
@@ -1,6 +1,6 @@
 //
 //  GradientActionButton.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 3/30/26.
 //

--- a/Pollector/Global/Components/CategoryChip.swift
+++ b/Pollector/Global/Components/CategoryChip.swift
@@ -1,6 +1,6 @@
 //
 //  CategoryChip.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 4/20/26.
 //

--- a/Pollector/Global/Components/CategoryScrollView.swift
+++ b/Pollector/Global/Components/CategoryScrollView.swift
@@ -1,6 +1,6 @@
 //
 //  CategoryScrollView.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 4/20/26.
 //

--- a/Pollector/Global/Components/CustomTextView.swift
+++ b/Pollector/Global/Components/CustomTextView.swift
@@ -1,6 +1,6 @@
 //
 //  CustomTextView.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 4/1/26.
 //

--- a/Pollector/Global/Components/CustomTextView.swift
+++ b/Pollector/Global/Components/CustomTextView.swift
@@ -11,6 +11,7 @@ struct CustomTextView: View {
     @Binding var text: String
     var placeholder: String = "내용을 입력해주세요"
     var isDisabled: Bool = false
+    var isFocused: FocusState<Bool>.Binding?
 
     var body: some View {
         ZStack(alignment: .topLeading) {
@@ -23,13 +24,24 @@ struct CustomTextView: View {
                     .zIndex(1)
             }
 
-            TextEditor(text: $text)
-                .font(.body4)
-                .scrollContentBackground(.hidden)
-                .padding(10)
-                .background(Color.clear)
-                .disabled(isDisabled)
-                .zIndex(0)
+            if let isFocused {
+                TextEditor(text: $text)
+                    .focused(isFocused)
+                    .font(.body4)
+                    .scrollContentBackground(.hidden)
+                    .padding(10)
+                    .background(Color.clear)
+                    .disabled(isDisabled)
+                    .zIndex(0)
+            } else {
+                TextEditor(text: $text)
+                    .font(.body4)
+                    .scrollContentBackground(.hidden)
+                    .padding(10)
+                    .background(Color.clear)
+                    .disabled(isDisabled)
+                    .zIndex(0)
+            }
         }
         .frame(height: 198)
         .background(

--- a/Pollector/Global/Components/CustomTextView.swift
+++ b/Pollector/Global/Components/CustomTextView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct CustomTextView: View {
     @Binding var text: String
     var placeholder: String = "내용을 입력해주세요"
+    var isDisabled: Bool = false
 
     var body: some View {
         ZStack(alignment: .topLeading) {
@@ -27,6 +28,7 @@ struct CustomTextView: View {
                 .scrollContentBackground(.hidden)
                 .padding(10)
                 .background(Color.clear)
+                .disabled(isDisabled)
                 .zIndex(0)
         }
         .frame(height: 198)

--- a/Pollector/Global/Components/DropDownView.swift
+++ b/Pollector/Global/Components/DropDownView.swift
@@ -1,6 +1,6 @@
 //
 //  DropDownView.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 3/28/26.
 //

--- a/Pollector/Global/Components/ImagePickerView.swift
+++ b/Pollector/Global/Components/ImagePickerView.swift
@@ -10,10 +10,11 @@ import PhotosUI
 
 struct ImagePickerView: View {
     let width: CGFloat
+    @Binding var selectedImages: [UIImage]
+    var isLocked: Bool = false
 
     private let maxImageCount = 3
     @State private var selectedItems: [PhotosPickerItem] = []
-    @State private var selectedImages: [UIImage] = []
 
     private var cellSize: CGFloat {
         max(0, (width - 16) / 3)
@@ -21,12 +22,12 @@ struct ImagePickerView: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            if selectedImages.count < maxImageCount {
+            if !isLocked && selectedImages.count < maxImageCount {
                 addPhotoCell
             }
 
             ForEach(Array(selectedImages.enumerated()), id: \.offset) { index, image in
-                removablePhotoCell(image: image, index: index)
+                photoCell(image: image, index: index)
             }
         }
         .frame(height: cellSize)
@@ -60,23 +61,25 @@ struct ImagePickerView: View {
         }
     }
 
-    private func removablePhotoCell(image: UIImage, index: Int) -> some View {
+    private func photoCell(image: UIImage, index: Int) -> some View {
         Image(uiImage: image)
             .resizable()
             .scaledToFill()
             .frame(width: cellSize, height: cellSize)
             .clipShape(RoundedRectangle(cornerRadius: 18))
             .overlay(alignment: .topTrailing) {
-                Button {
-                    removeImage(at: index)
-                } label: {
-                    Image(systemName: "xmark.circle")
-                        .font(.system(size: 20))
-                        .symbolRenderingMode(.palette)
-                        .foregroundStyle(.white, .black.opacity(0.45))
-                        .padding(12)
+                if !isLocked {
+                    Button {
+                        removeImage(at: index)
+                    } label: {
+                        Image(systemName: "xmark.circle")
+                            .font(.system(size: 20))
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(.white, .black.opacity(0.45))
+                            .padding(12)
+                    }
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
             }
     }
 

--- a/Pollector/Global/Components/ImagePickerView.swift
+++ b/Pollector/Global/Components/ImagePickerView.swift
@@ -6,12 +6,14 @@
 //
 
 import SwiftUI
+import PhotosUI
 
 struct ImagePickerView: View {
     let width: CGFloat
 
     private let maxImageCount = 3
-    @State private var selectedImageCount = 2
+    @State private var selectedItems: [PhotosPickerItem] = []
+    @State private var selectedImages: [UIImage] = []
 
     private var cellSize: CGFloat {
         max(0, (width - 16) / 3)
@@ -19,46 +21,92 @@ struct ImagePickerView: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            ForEach(0..<maxImageCount, id: \.self) { index in
-                if index == 0 {
-                    addPhotoCell
-                } else {
-                    removablePhotoCell
-                }
+            addPhotoCell
+
+            ForEach(Array(selectedImages.enumerated()), id: \.offset) { index, image in
+                removablePhotoCell(image: image, index: index)
             }
         }
         .frame(height: cellSize)
+        .onChange(of: selectedItems) { _, newItems in
+            Task {
+                await loadSelectedImages(from: newItems)
+            }
+        }
     }
 
     private var addPhotoCell: some View {
-        RoundedRectangle(cornerRadius: 18)
-            .fill(.gray1)
-            .frame(width: cellSize, height: cellSize)
-            .overlay {
-                VStack(spacing: 8) {
-                    Image(systemName: "photo.badge.plus")
-                        .font(.system(size: 25))
-                        .foregroundStyle(.gray5)
+        PhotosPicker(
+            selection: $selectedItems,
+            maxSelectionCount: max(0, maxImageCount - selectedImages.count),
+            matching: .images
+        ) {
+            RoundedRectangle(cornerRadius: 18)
+                .fill(.gray1)
+                .frame(width: cellSize, height: cellSize)
+                .overlay {
+                    VStack(spacing: 8) {
+                        Image(systemName: "photo.badge.plus")
+                            .font(.system(size: 25))
+                            .foregroundStyle(.gray5)
 
-                    Text("\(selectedImageCount) / \(maxImageCount)")
-                        .font(.head4)
-                        .foregroundStyle(.gray5)
+                        Text("\(selectedImages.count) / \(maxImageCount)")
+                            .font(.head4)
+                            .foregroundStyle(.gray5)
+                    }
                 }
-            }
+        }
+        .disabled(selectedImages.count >= maxImageCount)
     }
 
-    private var removablePhotoCell: some View {
-        RoundedRectangle(cornerRadius: 18)
-            .fill(.gray1)
+    private func removablePhotoCell(image: UIImage, index: Int) -> some View {
+        Image(uiImage: image)
+            .resizable()
+            .scaledToFill()
             .frame(width: cellSize, height: cellSize)
+            .clipShape(RoundedRectangle(cornerRadius: 18))
             .overlay(alignment: .topTrailing) {
                 Button {
+                    removeImage(at: index)
                 } label: {
                     Image(systemName: "xmark.circle")
                         .font(.system(size: 20))
-                        .foregroundStyle(.gray5)
+                        .symbolRenderingMode(.palette)
+                        .foregroundStyle(.white, .black.opacity(0.45))
                         .padding(12)
                 }
+                .buttonStyle(.plain)
             }
+    }
+
+    @MainActor
+    private func loadSelectedImages(from items: [PhotosPickerItem]) async {
+        let remainingCount = max(0, maxImageCount - selectedImages.count)
+        guard remainingCount > 0 else {
+            selectedItems = []
+            return
+        }
+
+        var loadedImages: [UIImage] = []
+
+        for item in items.prefix(remainingCount) {
+            guard let data = try? await item.loadTransferable(type: Data.self),
+                  let image = UIImage(data: data) else {
+                continue
+            }
+
+            loadedImages.append(image)
+        }
+
+        selectedImages.append(contentsOf: loadedImages)
+        selectedItems = []
+    }
+
+    private func removeImage(at index: Int) {
+        guard selectedImages.indices.contains(index) else {
+            return
+        }
+
+        selectedImages.remove(at: index)
     }
 }

--- a/Pollector/Global/Components/ImagePickerView.swift
+++ b/Pollector/Global/Components/ImagePickerView.swift
@@ -1,6 +1,6 @@
 //
 //  ImagePickerView.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 4/20/26.
 //

--- a/Pollector/Global/Components/ImagePickerView.swift
+++ b/Pollector/Global/Components/ImagePickerView.swift
@@ -21,7 +21,9 @@ struct ImagePickerView: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            addPhotoCell
+            if selectedImages.count < maxImageCount {
+                addPhotoCell
+            }
 
             ForEach(Array(selectedImages.enumerated()), id: \.offset) { index, image in
                 removablePhotoCell(image: image, index: index)
@@ -56,7 +58,6 @@ struct ImagePickerView: View {
                     }
                 }
         }
-        .disabled(selectedImages.count >= maxImageCount)
     }
 
     private func removablePhotoCell(image: UIImage, index: Int) -> some View {

--- a/Pollector/Global/Components/InfoRow.swift
+++ b/Pollector/Global/Components/InfoRow.swift
@@ -1,6 +1,6 @@
 //
 //  InfoRow.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 4/1/26.
 //

--- a/Pollector/Global/Components/PageControl.swift
+++ b/Pollector/Global/Components/PageControl.swift
@@ -1,6 +1,6 @@
 //
 //  PageControl.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 4/20/26.
 //

--- a/Pollector/Global/Components/PageControl.swift
+++ b/Pollector/Global/Components/PageControl.swift
@@ -20,7 +20,7 @@ struct PageControl: View {
                 let width = isCurrentPage ? height * 2 : height
                 
                 Capsule()
-                    .fill(isCurrentPage ? Color.neutral8 : Color.neutral3)
+                    .fill(isCurrentPage ? Color.white : Color.neutral7)
                     .frame(width: width, height: height)
             }
         }

--- a/Pollector/Global/Components/StampStatusView.swift
+++ b/Pollector/Global/Components/StampStatusView.swift
@@ -1,6 +1,6 @@
 //
 //  StampStatusView.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 3/28/26.
 //

--- a/Pollector/Global/Components/Toast/FancyToast.swift
+++ b/Pollector/Global/Components/Toast/FancyToast.swift
@@ -1,0 +1,13 @@
+//
+//  FancyToast.swift
+//  Pollector
+//
+//  Created by 이은지 on 4/23/26.
+//
+
+import Foundation
+
+struct FancyToast: Equatable {
+    var message: String
+    var duration: Double = 2
+}

--- a/Pollector/Global/Components/Toast/FancyToastModifier.swift
+++ b/Pollector/Global/Components/Toast/FancyToastModifier.swift
@@ -1,0 +1,69 @@
+//
+//  FancyToastModifier.swift
+//  Pollector
+//
+//  Created by 이은지 on 4/23/26.
+//
+
+import SwiftUI
+
+struct FancyToastModifier: ViewModifier {
+    @Binding var toast: FancyToast?
+    @State private var workItem: DispatchWorkItem?
+    
+    func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .overlay(
+                ZStack {
+                    mainToastView()
+                        .offset(y: -30)
+                }.animation(.spring(), value: toast)
+            )
+            .onChange(of: toast) {
+                showToast()
+            }
+    }
+    
+    @ViewBuilder func mainToastView() -> some View {
+        if let toast = toast {
+            VStack {
+                Spacer()
+                FancyToastView(message: toast.message)
+            }
+            .transition(.move(edge: .bottom))
+        }
+    }
+    
+    private func showToast() {
+        guard let toast = toast else { return }
+        
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        
+        if toast.duration > 0 {
+            workItem?.cancel()
+            
+            let task = DispatchWorkItem {
+               dismissToast()
+            }
+            
+            workItem = task
+            DispatchQueue.main.asyncAfter(deadline: .now() + toast.duration, execute: task)
+        }
+    }
+    
+    private func dismissToast() {
+        withAnimation {
+            toast = nil
+        }
+        
+        workItem?.cancel()
+        workItem = nil
+    }
+}
+
+extension View {
+    func toastView(toast: Binding<FancyToast?>) -> some View {
+        self.modifier(FancyToastModifier(toast: toast))
+    }
+}

--- a/Pollector/Global/Components/Toast/FancyToastView.swift
+++ b/Pollector/Global/Components/Toast/FancyToastView.swift
@@ -1,0 +1,43 @@
+//
+//  FancyToastView.swift
+//  Pollector
+//
+//  Created by 이은지 on 4/23/26.
+//
+
+import SwiftUI
+
+struct FancyToastView: View {
+    var message: String
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading) {
+                    Text(message)
+                        .font(.body1)
+                        .foregroundColor(.neutral10)
+                }
+                
+                Spacer(minLength: 10)
+            }
+            .padding(.all, 18)
+        }
+        .background(.white)
+        .overlay(
+            Rectangle()
+                .fill(.neutral5)
+                .frame(width: 6)
+                .clipped()
+            , alignment: .leading
+        )
+        .frame(minWidth: 0, maxWidth: .infinity)
+        .cornerRadius(8)
+        .shadow(color: Color.black.opacity(0.25), radius: 4, x: 0, y: 1)
+        .padding(.horizontal, 16)
+    }
+}
+
+#Preview {
+    FancyToastView(message: "메시지")
+}

--- a/Pollector/Global/Extension/Date+Extension.swift
+++ b/Pollector/Global/Extension/Date+Extension.swift
@@ -1,6 +1,6 @@
 //
 //  Date+Extension.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 4/20/26.
 //

--- a/Pollector/Global/Extension/Font+Extension.swift
+++ b/Pollector/Global/Extension/Font+Extension.swift
@@ -1,6 +1,6 @@
 //
 //  Font+Extension.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 3/28/26.
 //

--- a/Pollector/Network/DTO/PlacesDTO.swift
+++ b/Pollector/Network/DTO/PlacesDTO.swift
@@ -1,6 +1,6 @@
 //
 //  PlacesDTO.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 4/22/26.
 //

--- a/Pollector/Network/Error/NetworkError.swift
+++ b/Pollector/Network/Error/NetworkError.swift
@@ -1,6 +1,6 @@
 //
 //  NetworkError.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 4/21/26.
 //

--- a/Pollector/Network/Model/DropDownModel.swift
+++ b/Pollector/Network/Model/DropDownModel.swift
@@ -1,6 +1,6 @@
 //
 //  DropDownModel.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 3/31/26.
 //

--- a/Pollector/Network/Model/Places.swift
+++ b/Pollector/Network/Model/Places.swift
@@ -1,6 +1,6 @@
 //
 //  Places.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 4/22/26.
 //

--- a/Pollector/Network/Model/Places.swift
+++ b/Pollector/Network/Model/Places.swift
@@ -59,7 +59,7 @@ final class Places {
 
     var sortedPhotos: [PlacesPhoto] {
         photos.sorted { lhs, rhs in
-            lhs.sortIndex < rhs.sortIndex
+            lhs.sortIndexValue < rhs.sortIndexValue
         }
     }
 }
@@ -70,7 +70,7 @@ final class PlacesPhoto {
     var width: Int
     var height: Int
     var imageData: Data?
-    var sortIndex: Int
+    var sortIndex: Int?
 
     init(
         reference: String,
@@ -84,5 +84,9 @@ final class PlacesPhoto {
         self.height = height
         self.imageData = imageData
         self.sortIndex = sortIndex
+    }
+
+    var sortIndexValue: Int {
+        sortIndex ?? 0
     }
 }

--- a/Pollector/Network/Model/Places.swift
+++ b/Pollector/Network/Model/Places.swift
@@ -51,10 +51,16 @@ final class Places {
     }
 
     var primaryPhoto: PlacesPhoto? {
-        photos.first { photo in
+        sortedPhotos.first { photo in
             guard let imageData = photo.imageData else { return false }
             return !imageData.isEmpty
-        } ?? photos.first
+        } ?? sortedPhotos.first
+    }
+
+    var sortedPhotos: [PlacesPhoto] {
+        photos.sorted { lhs, rhs in
+            lhs.sortIndex < rhs.sortIndex
+        }
     }
 }
 
@@ -64,11 +70,19 @@ final class PlacesPhoto {
     var width: Int
     var height: Int
     var imageData: Data?
+    var sortIndex: Int
 
-    init(reference: String, width: Int, height: Int, imageData: Data? = nil) {
+    init(
+        reference: String,
+        width: Int,
+        height: Int,
+        imageData: Data? = nil,
+        sortIndex: Int = 0
+    ) {
         self.reference = reference
         self.width = width
         self.height = height
         self.imageData = imageData
+        self.sortIndex = sortIndex
     }
 }

--- a/Pollector/Network/Model/StampCompletionModel.swift
+++ b/Pollector/Network/Model/StampCompletionModel.swift
@@ -1,6 +1,6 @@
 //
 //  StampCompletionModel.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by Codex on 4/22/26.
 //

--- a/Pollector/Network/Model/StampCompletionModel.swift
+++ b/Pollector/Network/Model/StampCompletionModel.swift
@@ -15,7 +15,7 @@ final class StampCompletionModel {
     var placeCacheKey: String
     var placeID: String?
     var placeName: String
-    var reviewText: String
+    var reviewText: String?
     var completedDate: Date
 
     @Relationship(deleteRule: .cascade)
@@ -26,7 +26,7 @@ final class StampCompletionModel {
         placeCacheKey: String,
         placeID: String? = nil,
         placeName: String,
-        reviewText: String = "",
+        reviewText: String? = nil,
         photos: [StampCompletionPhoto] = [],
         completedDate: Date = Date()
     ) {

--- a/Pollector/Network/Model/StampCompletionModel.swift
+++ b/Pollector/Network/Model/StampCompletionModel.swift
@@ -15,13 +15,19 @@ final class StampCompletionModel {
     var placeCacheKey: String
     var placeID: String?
     var placeName: String
+    var reviewText: String
     var completedDate: Date
+
+    @Relationship(deleteRule: .cascade)
+    var photos: [StampCompletionPhoto]
 
     init(
         keyword: String,
         placeCacheKey: String,
         placeID: String? = nil,
         placeName: String,
+        reviewText: String = "",
+        photos: [StampCompletionPhoto] = [],
         completedDate: Date = Date()
     ) {
         self.id = StampCompletionModel.makeID(keyword: keyword)
@@ -29,10 +35,31 @@ final class StampCompletionModel {
         self.placeCacheKey = placeCacheKey
         self.placeID = placeID
         self.placeName = placeName
+        self.reviewText = reviewText
+        self.photos = photos
         self.completedDate = completedDate
     }
 
     static func makeID(keyword: String) -> String {
         "stamp-completion:\(keyword)"
+    }
+}
+
+extension StampCompletionModel {
+    var sortedPhotos: [StampCompletionPhoto] {
+        photos.sorted { lhs, rhs in
+            lhs.sortIndex < rhs.sortIndex
+        }
+    }
+}
+
+@Model
+final class StampCompletionPhoto {
+    var imageData: Data
+    var sortIndex: Int
+
+    init(imageData: Data, sortIndex: Int) {
+        self.imageData = imageData
+        self.sortIndex = sortIndex
     }
 }

--- a/Pollector/Network/Model/StampDetailModel.swift
+++ b/Pollector/Network/Model/StampDetailModel.swift
@@ -1,6 +1,6 @@
 //
 //  StampDetailModel.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by Codex on 4/1/26.
 //

--- a/Pollector/Network/Model/StampDetailModel.swift
+++ b/Pollector/Network/Model/StampDetailModel.swift
@@ -40,7 +40,7 @@ extension StampDetailModel {
             reviewTitle: "리뷰 작성하기",
             reviewPrompt: "오늘의 순간을 사진과 함께 기록해보세요",
             reviewPlaceholder: "자유롭게 기록해보세요",
-            actionButtonTitle: "스탬프 받기",
+            actionButtonTitle: "기록 남기기",
             actionButtonImageName: "completeIcon"
         )
     }

--- a/Pollector/Network/Model/StampDetailModel.swift
+++ b/Pollector/Network/Model/StampDetailModel.swift
@@ -37,7 +37,7 @@ extension StampDetailModel {
             address: address,
             distanceText: distanceText,
             priceText: priceText,
-            reviewTitle: "리뷰 작성하기",
+            reviewTitle: "기록 작성하기",
             reviewPrompt: "오늘의 순간을 사진과 함께 기록해보세요",
             reviewPlaceholder: "자유롭게 기록해보세요",
             actionButtonTitle: "기록 남기기",

--- a/Pollector/Network/Model/StampListModel.swift
+++ b/Pollector/Network/Model/StampListModel.swift
@@ -1,6 +1,6 @@
 //
 //  StampListModel.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 4/21/26.
 //

--- a/Pollector/Network/PlacesService.swift
+++ b/Pollector/Network/PlacesService.swift
@@ -46,7 +46,7 @@ final class PlacesService: PlacesServicing {
             placeProperties: properties,
             locationBias: pohangBias,
             includedType: nil,
-            maxResultCount: 10,
+            maxResultCount: 1,
             minRating: 0.0,
             isOpenNow: false,
             priceLevels: nil,

--- a/Pollector/Network/PlacesService.swift
+++ b/Pollector/Network/PlacesService.swift
@@ -1,6 +1,6 @@
 //
 //  PlacesService.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 4/21/26.
 //

--- a/Pollector/View/CustomTabView.swift
+++ b/Pollector/View/CustomTabView.swift
@@ -1,6 +1,6 @@
 //
 //  CustomTabView.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 4/19/26.
 //

--- a/Pollector/View/HomeView.swift
+++ b/Pollector/View/HomeView.swift
@@ -78,9 +78,7 @@ struct HomeView: View {
                 StampDetailView(
                     place: selectedPlace,
                     isCompleted: completedKeywords.contains(selectedPlace.keyword)
-                ) {
-                    completeStamp(for: selectedPlace)
-                }
+                )
             }
         }
         .task(id: selectedDropDown.id) {
@@ -101,34 +99,6 @@ struct HomeView: View {
                 .filter { selectedDropDown.keywords.contains($0.keyword) }
                 .map(\.keyword)
         )
-    }
-
-    private func completeStamp(for place: Places) {
-        let completionID = StampCompletionModel.makeID(keyword: place.keyword)
-        let descriptor = FetchDescriptor<StampCompletionModel>(
-            predicate: #Predicate { completion in
-                completion.id == completionID
-            }
-        )
-
-        if let existingCompletion = try? modelContext.fetch(descriptor).first {
-            existingCompletion.placeCacheKey = place.cacheKey
-            existingCompletion.placeID = place.placeID
-            existingCompletion.placeName = place.name
-            existingCompletion.completedDate = Date()
-        } else {
-            let completion = StampCompletionModel(
-                keyword: place.keyword,
-                placeCacheKey: place.cacheKey,
-                placeID: place.placeID,
-                placeName: place.name
-            )
-
-            modelContext.insert(completion)
-        }
-
-        try? modelContext.save()
-        showsPlaceDetail = false
     }
 }
 

--- a/Pollector/View/HomeView.swift
+++ b/Pollector/View/HomeView.swift
@@ -75,7 +75,10 @@ struct HomeView: View {
         }
         .navigationDestination(isPresented: $showsPlaceDetail) {
             if let selectedPlace {
-                StampDetailView(place: selectedPlace) {
+                StampDetailView(
+                    place: selectedPlace,
+                    isCompleted: completedKeywords.contains(selectedPlace.keyword)
+                ) {
                     completeStamp(for: selectedPlace)
                 }
             }

--- a/Pollector/View/HomeView.swift
+++ b/Pollector/View/HomeView.swift
@@ -13,6 +13,7 @@ struct HomeView: View {
     @Query private var completedStamps: [StampCompletionModel]
     @State private var selectedPlace: Places?
     @State private var showsPlaceDetail = false
+    @State private var toast: FancyToast? = nil
     @State private var showModal = false
     @State private var selectedDropDown = DropDownModel.samples[0]
     @StateObject private var searchViewModel = SearchViewModel()
@@ -73,12 +74,15 @@ struct HomeView: View {
                 }
             }
         }
+        .toastView(toast: $toast)
         .navigationDestination(isPresented: $showsPlaceDetail) {
             if let selectedPlace {
                 StampDetailView(
                     place: selectedPlace,
                     isCompleted: completedKeywords.contains(selectedPlace.keyword)
-                )
+                ) {
+                    toast = FancyToast(message: "기록을 남겼어요")
+                }
             }
         }
         .task(id: selectedDropDown.id) {

--- a/Pollector/View/HomeView.swift
+++ b/Pollector/View/HomeView.swift
@@ -1,6 +1,6 @@
 //
 //  HomeView.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 3/27/26.
 //

--- a/Pollector/View/MapView.swift
+++ b/Pollector/View/MapView.swift
@@ -1,6 +1,6 @@
 //
 //  MapView.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 4/19/26.
 //

--- a/Pollector/View/StampDetailView.swift
+++ b/Pollector/View/StampDetailView.swift
@@ -10,6 +10,7 @@ import UIKit
 
 struct StampDetailView: View {
     let place: Places
+    let isCompleted: Bool
     let onStampCompleted: () -> Void
     @State private var toast: FancyToast? = nil
 
@@ -101,14 +102,16 @@ struct StampDetailView: View {
                 .padding(.horizontal, 16)
 
                 ActionButton(
-                    title: "기록 남기기",
-                    imageName: "pencil"
+                    title: isCompleted ? "기록 완료" : "기록 남기기",
+                    imageName: "pencil",
+                    backgroundColor: isCompleted ? Color.gray8 : Color.neutral4,
+                    isDisabled: isCompleted
                 ) {
                     stampButtonTapped()
                 }
                 .padding(.top, 24)
                 .padding(.horizontal, 24)
-                .padding(.bottom, 24)
+                .padding(.bottom, 32)
             }
             .background(Color.white)
             .ignoresSafeArea()
@@ -118,6 +121,7 @@ struct StampDetailView: View {
     }
 
     private func stampButtonTapped() {
+        guard !isCompleted else { return }
         onStampCompleted()
         dismiss()
     }
@@ -184,6 +188,7 @@ extension PlaceImageItem: Identifiable {}
             name: "포항 미리보기",
             address: "경북 포항시"
         ),
+        isCompleted: false,
         onStampCompleted: {}
     )
 }

--- a/Pollector/View/StampDetailView.swift
+++ b/Pollector/View/StampDetailView.swift
@@ -74,7 +74,7 @@ struct StampDetailView: View {
                     }
 
                     VStack(alignment: .leading, spacing: 0) {
-                        Text("리뷰 작성하기")
+                        Text("기록 작성하기")
                             .font(.head1)
                             .foregroundStyle(.neutral10)
                             .padding(.bottom, 8)

--- a/Pollector/View/StampDetailView.swift
+++ b/Pollector/View/StampDetailView.swift
@@ -14,10 +14,7 @@ struct StampDetailView: View {
 
     @Environment(\.dismiss) private var dismiss
     @State private var reviewText = ""
-
-    let array: [Color] = [.red, .green, .blue]
-    @State var selection = 0
-    
+    @State private var selection = 0
     @State private var isBookmarked = false
 
     var body: some View {
@@ -25,14 +22,14 @@ struct StampDetailView: View {
             let contentWidth = max(0, geometry.size.width - 32)
 
             ScrollView {
-                placeImage
+                placeImagePager
                     .frame(height: 240)
                     .frame(maxWidth: .infinity)
                     .clipped()
                     .padding(.top, 10)
                     .padding(.bottom, 16)
 
-                PageControl(numberOfPages: array.count, currentPage: $selection)
+                PageControl(numberOfPages: pageCount, currentPage: $selection)
                     .padding(.bottom, 16)
 
                 VStack(alignment: .leading, spacing: 0) {
@@ -152,19 +149,58 @@ struct StampDetailView: View {
     }
 
     @ViewBuilder
-    private var placeImage: some View {
-        if let imageData = place.primaryPhoto?.imageData,
-           let image = UIImage(data: imageData) {
-            Image(uiImage: image)
-                .resizable()
-                .scaledToFill()
-        } else {
-            Image(.imageDefault)
-                .resizable()
-                .scaledToFill()
+    private var placeImagePager: some View {
+        let imageItems = placeImageItems
+
+        TabView(selection: $selection) {
+            if imageItems.isEmpty {
+                fallbackPlaceImage
+                    .tag(0)
+            } else {
+                ForEach(Array(imageItems.enumerated()), id: \.element.id) { index, item in
+                    Image(uiImage: item.image)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(maxWidth: .infinity)
+                        .clipped()
+                        .tag(index)
+                }
+            }
+        }
+        .tabViewStyle(.page(indexDisplayMode: .never))
+    }
+
+    private var pageCount: Int {
+        max(placeImageItems.count, 1)
+    }
+
+    private var placeImageItems: [PlaceImageItem] {
+        place.sortedPhotos.compactMap { photo in
+            guard let imageData = photo.imageData,
+                  let image = UIImage(data: imageData) else {
+                return nil
+            }
+
+            return PlaceImageItem(
+                id: "\(photo.sortIndex)-\(photo.reference)",
+                image: image
+            )
         }
     }
+
+    private var fallbackPlaceImage: some View {
+        Image(.imageDefault)
+            .resizable()
+            .scaledToFill()
+    }
 }
+
+private struct PlaceImageItem {
+    let id: String
+    let image: UIImage
+}
+
+extension PlaceImageItem: Identifiable {}
 
 #Preview {
     StampDetailView(

--- a/Pollector/View/StampDetailView.swift
+++ b/Pollector/View/StampDetailView.swift
@@ -133,13 +133,6 @@ struct StampDetailView: View {
             }
             .background(Color.white)
             .toolbar(.hidden, for: .tabBar)
-            .toolbar {
-                Button {
-                    isBookmarked.toggle()
-                } label: {
-                    Image(systemName: isBookmarked ? "bookmark.fill" : "bookmark")
-                }
-            }
         }
     }
 

--- a/Pollector/View/StampDetailView.swift
+++ b/Pollector/View/StampDetailView.swift
@@ -204,7 +204,7 @@ struct StampDetailView: View {
             return
         }
 
-        reviewText = completion.reviewText
+        reviewText = completion.reviewText ?? ""
         selectedImages = completion.sortedPhotos.compactMap { photo in
             UIImage(data: photo.imageData)
         }

--- a/Pollector/View/StampDetailView.swift
+++ b/Pollector/View/StampDetailView.swift
@@ -7,16 +7,24 @@
 
 import SwiftUI
 import UIKit
+import SwiftData
 
 struct StampDetailView: View {
     let place: Places
-    let isCompleted: Bool
-    let onStampCompleted: () -> Void
+
+    @Environment(\.modelContext) private var modelContext
     @State private var toast: FancyToast? = nil
 
     @Environment(\.dismiss) private var dismiss
     @State private var reviewText = ""
     @State private var selection = 0
+    @State private var selectedImages: [UIImage] = []
+    @State private var hasCompletedRecord: Bool
+
+    init(place: Places, isCompleted: Bool) {
+        self.place = place
+        _hasCompletedRecord = State(initialValue: isCompleted)
+    }
 
     var body: some View {
         GeometryReader { geometry in
@@ -90,22 +98,27 @@ struct StampDetailView: View {
                             .foregroundStyle(.neutral10)
                             .padding(.bottom, 8)
 
-                        ImagePickerView(width: contentWidth)
+                        ImagePickerView(
+                            width: contentWidth,
+                            selectedImages: $selectedImages,
+                            isLocked: hasCompletedRecord
+                        )
                     }
                     .padding(.horizontal, 16)
                 }
 
                 CustomTextView(
                     text: $reviewText,
-                    placeholder: "자유롭게 기록해보세요"
+                    placeholder: "자유롭게 기록해보세요",
+                    isDisabled: hasCompletedRecord
                 )
                 .padding(.horizontal, 16)
 
                 ActionButton(
                     title: isCompleted ? "기록 완료" : "기록 남기기",
                     imageName: "pencil",
-                    backgroundColor: isCompleted ? Color.gray8 : Color.neutral4,
-                    isDisabled: isCompleted
+                    backgroundColor: hasCompletedRecord ? Color.gray8 : Color.neutral4,
+                    isDisabled: hasCompletedRecord
                 ) {
                     stampButtonTapped()
                 }
@@ -117,13 +130,85 @@ struct StampDetailView: View {
             .ignoresSafeArea()
             .toolbar(.hidden, for: .tabBar)
             .toastView(toast: $toast)
+            .task(id: place.keyword) {
+                loadSavedCompletion()
+            }
         }
     }
 
     private func stampButtonTapped() {
-        guard !isCompleted else { return }
-        onStampCompleted()
+        guard !hasCompletedRecord else { return }
+
+        let trimmedReviewText = reviewText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let photoModels = selectedImages.enumerated().compactMap { item -> StampCompletionPhoto? in
+            let (index, image) = item
+
+            guard let imageData = image.jpegData(compressionQuality: 0.85) else {
+                return nil
+            }
+
+            return StampCompletionPhoto(imageData: imageData, sortIndex: index)
+        }
+
+        for photoModel in photoModels {
+            modelContext.insert(photoModel)
+        }
+
+        let completionID = StampCompletionModel.makeID(keyword: place.keyword)
+        let descriptor = FetchDescriptor<StampCompletionModel>(
+            predicate: #Predicate { completion in
+                completion.id == completionID
+            }
+        )
+
+        if let existingCompletion = try? modelContext.fetch(descriptor).first {
+            existingCompletion.placeCacheKey = place.cacheKey
+            existingCompletion.placeID = place.placeID
+            existingCompletion.placeName = place.name
+            existingCompletion.reviewText = trimmedReviewText
+            existingCompletion.completedDate = Date()
+
+            for photo in existingCompletion.photos {
+                modelContext.delete(photo)
+            }
+
+            existingCompletion.photos = photoModels
+        } else {
+            let completion = StampCompletionModel(
+                keyword: place.keyword,
+                placeCacheKey: place.cacheKey,
+                placeID: place.placeID,
+                placeName: place.name,
+                reviewText: trimmedReviewText,
+                photos: photoModels
+            )
+
+            modelContext.insert(completion)
+        }
+
+        try? modelContext.save()
+        hasCompletedRecord = true
+        toast = FancyToast(message: "기록을 저장했어요")
         dismiss()
+    }
+
+    private func loadSavedCompletion() {
+        let completionID = StampCompletionModel.makeID(keyword: place.keyword)
+        let descriptor = FetchDescriptor<StampCompletionModel>(
+            predicate: #Predicate { completion in
+                completion.id == completionID
+            }
+        )
+
+        guard let completion = try? modelContext.fetch(descriptor).first else {
+            return
+        }
+
+        reviewText = completion.reviewText
+        selectedImages = completion.sortedPhotos.compactMap { photo in
+            UIImage(data: photo.imageData)
+        }
+        hasCompletedRecord = true
     }
 
     @ViewBuilder
@@ -188,7 +273,6 @@ extension PlaceImageItem: Identifiable {}
             name: "포항 미리보기",
             address: "경북 포항시"
         ),
-        isCompleted: false,
-        onStampCompleted: {}
+        isCompleted: false
     )
 }

--- a/Pollector/View/StampDetailView.swift
+++ b/Pollector/View/StampDetailView.swift
@@ -24,10 +24,9 @@ struct StampDetailView: View {
             ScrollView {
                 ZStack(alignment: .bottom) {
                     placeImagePager
-                        .frame(height: 240)
+                        .frame(height: 300)
                         .frame(maxWidth: .infinity)
                         .clipped()
-                        .padding(.top, 10)
                     
                     PageControl(numberOfPages: pageCount, currentPage: $selection)
                         .padding(.bottom, 16)
@@ -36,7 +35,7 @@ struct StampDetailView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     HStack {
                         Text(place.name)
-                            .font(.head1)
+                            .font(.display2)
                             .foregroundStyle(.neutral10)
                             .padding(.top, 16)
 
@@ -102,8 +101,8 @@ struct StampDetailView: View {
                 .padding(.horizontal, 16)
 
                 ActionButton(
-                    title: "스탬프 받기",
-                    imageName: "completeIcon"
+                    title: "기록 남기기",
+                    imageName: "pencil"
                 ) {
                     stampButtonTapped()
                 }
@@ -112,6 +111,7 @@ struct StampDetailView: View {
                 .padding(.bottom, 24)
             }
             .background(Color.white)
+            .ignoresSafeArea()
             .toolbar(.hidden, for: .tabBar)
             .toastView(toast: $toast)
         }

--- a/Pollector/View/StampDetailView.swift
+++ b/Pollector/View/StampDetailView.swift
@@ -12,6 +12,8 @@ import SwiftData
 struct StampDetailView: View {
     let place: Places
     let onSaved: () -> Void
+    private let reviewSectionID = "review-section"
+    private let actionButtonID = "action-button"
 
     @Environment(\.modelContext) private var modelContext
     @State private var toast: FancyToast? = nil
@@ -21,6 +23,8 @@ struct StampDetailView: View {
     @State private var selection = 0
     @State private var selectedImages: [UIImage] = []
     @State private var hasCompletedRecord: Bool
+    @State private var keyboardHeight: CGFloat = 0
+    @FocusState private var isReviewFieldFocused: Bool
     private let maxReviewLength = 500
 
     init(place: Places, isCompleted: Bool, onSaved: @escaping () -> Void = {}) {
@@ -32,122 +36,141 @@ struct StampDetailView: View {
     var body: some View {
         GeometryReader { geometry in
             let contentWidth = max(0, geometry.size.width - 32)
+            let keyboardInset = keyboardHeight
 
-            ScrollView {
-                ZStack(alignment: .bottom) {
-                    placeImagePager
-                        .frame(height: 300)
-                        .frame(maxWidth: .infinity)
-                        .clipped()
-                    
-                    PageControl(numberOfPages: pageCount, currentPage: $selection)
-                        .padding(.bottom, 16)
-                }
-
-                VStack(alignment: .leading, spacing: 0) {
-                    HStack {
-                        Text(place.name)
-                            .font(.display2)
-                            .foregroundStyle(.neutral10)
-                            .padding(.top, 16)
-
-                        Spacer()
+            ScrollViewReader { proxy in
+                ScrollView {
+                    ZStack(alignment: .bottom) {
+                        placeImagePager
+                            .frame(height: 300)
+                            .frame(maxWidth: .infinity)
+                            .clipped()
+                        
+                        PageControl(numberOfPages: pageCount, currentPage: $selection)
+                            .padding(.bottom, 16)
                     }
-                    .padding(.leading, 16)
-                    .padding(.bottom, 8)
-                    
-                    VStack(spacing: 0) {
-                        HStack {
-                            Text(place.address ?? "위치 정보가 없어요")
-                                .font(.body4)
-                                .foregroundStyle(.neutral10)
 
-                            Button {
-                                if let address = place.address {
-                                    UIPasteboard.general.string = address
-                                }
-                                toast = FancyToast(message: "주소를 복사했어요")
-                            } label: {
-                                Text("복사")
-                                    .font(.micro2)
-                                    .padding(.horizontal, 8)
-                                    .padding(.vertical, 4)
-                                    .foregroundStyle(.neutral5)
-                                    .background {
-                                        RoundedRectangle(cornerRadius: 16)
-                                            .fill(Color.gray2)
-                                    }
-                            }
+                    VStack(alignment: .leading, spacing: 0) {
+                        HStack {
+                            Text(place.name)
+                                .font(.display2)
+                                .foregroundStyle(.neutral10)
+                                .padding(.top, 16)
 
                             Spacer()
                         }
                         .padding(.leading, 16)
-                        .padding(.bottom, 48)
-                    }
-
-                    VStack(alignment: .leading, spacing: 0) {
-                        Text("기록 작성하기")
-                            .font(.head1)
-                            .foregroundStyle(.neutral10)
-                            .padding(.bottom, 8)
-
-                        Text("오늘의 순간을 사진과 함께 기록해보세요")
-                            .font(.micro1)
-                            .foregroundStyle(.gray5)
-                            .padding(.bottom, 8)
-                        
-                        ImagePickerView(
-                            width: contentWidth,
-                            selectedImages: $selectedImages,
-                            isLocked: hasCompletedRecord
-                        )
                         .padding(.bottom, 8)
                         
-                        HStack {
-                            Text("\(Date().koreanDateString)에 방문")
-                                .foregroundStyle(.neutral10)
-                            
+                        VStack(spacing: 0) {
+                            HStack {
+                                Text(place.address ?? "위치 정보가 없어요")
+                                    .font(.body4)
+                                    .foregroundStyle(.neutral10)
+
+                                Button {
+                                    if let address = place.address {
+                                        UIPasteboard.general.string = address
+                                    }
+                                    toast = FancyToast(message: "주소를 복사했어요")
+                                } label: {
+                                    Text("복사")
+                                        .font(.micro2)
+                                        .padding(.horizontal, 8)
+                                        .padding(.vertical, 4)
+                                        .foregroundStyle(.neutral5)
+                                        .background {
+                                            RoundedRectangle(cornerRadius: 16)
+                                                .fill(Color.gray2)
+                                        }
+                                }
+
                             Spacer()
-                            
-                            Text("\(reviewText.count) / \(maxReviewLength)")
-                                .foregroundStyle(.neutral7)
                         }
-                        .font(.body4)
-                        .padding(.horizontal, 6)
-                        .padding(.bottom, 8)
+                            .padding(.leading, 16)
+                            .padding(.bottom, 48)
+                        }
+
+                        VStack(alignment: .leading, spacing: 0) {
+                            Text("기록 작성하기")
+                                .font(.head1)
+                                .foregroundStyle(.neutral10)
+                                .padding(.bottom, 8)
+
+                            Text("오늘의 순간을 사진과 함께 기록해보세요")
+                                .font(.micro1)
+                                .foregroundStyle(.gray5)
+                                .padding(.bottom, 8)
+                            
+                            ImagePickerView(
+                                width: contentWidth,
+                                selectedImages: $selectedImages,
+                                isLocked: hasCompletedRecord
+                            )
+                            .padding(.bottom, 8)
+                            
+                            HStack {
+                                Text("\(Date().koreanDateString)에 방문")
+                                    .foregroundStyle(.neutral10)
+                                
+                                Spacer()
+                                
+                                Text("\(reviewText.count) / \(maxReviewLength)")
+                                    .foregroundStyle(.neutral7)
+                            }
+                            .font(.body4)
+                            .padding(.horizontal, 6)
+                            .padding(.bottom, 8)
+                        }
+                        .padding(.horizontal, 16)
                     }
+
+                    CustomTextView(
+                        text: $reviewText,
+                        placeholder: "자유롭게 기록해보세요",
+                        isDisabled: hasCompletedRecord,
+                        isFocused: $isReviewFieldFocused
+                    )
+                    .id(reviewSectionID)
                     .padding(.horizontal, 16)
-                }
+                    .padding(.bottom, 24)
 
-                CustomTextView(
-                    text: $reviewText,
-                    placeholder: "자유롭게 기록해보세요",
-                    isDisabled: hasCompletedRecord
-                )
-                .padding(.horizontal, 16)
-                .padding(.bottom, 24)
-
-                ActionButton(
-                    title: hasCompletedRecord ? "기록 완료" : "기록 남기기",
-                    imageName: "pencil",
-                    backgroundColor: hasCompletedRecord ? Color.gray8 : Color.neutral4,
-                    isDisabled: hasCompletedRecord
-                ) {
-                    stampButtonTapped()
+                    ActionButton(
+                        title: hasCompletedRecord ? "기록 완료" : "기록 남기기",
+                        imageName: "pencil",
+                        backgroundColor: hasCompletedRecord ? Color.gray8 : Color.neutral4,
+                        isDisabled: hasCompletedRecord
+                    ) {
+                        stampButtonTapped()
+                    }
+                    .id(actionButtonID)
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 32 + keyboardInset)
                 }
-                .padding(.horizontal, 24)
-                .padding(.bottom, 32)
-            }
-            .background(Color.white)
-            .ignoresSafeArea()
-            .toolbar(.hidden, for: .tabBar)
-            .toastView(toast: $toast)
-            .onChange(of: reviewText) { _, newValue in
-                guard newValue.count > maxReviewLength else { return }
-                reviewText = String(newValue.prefix(maxReviewLength))
-            }
-            .task(id: place.keyword) {
-                loadSavedCompletion()
+                .scrollDismissesKeyboard(.interactively)
+                .background(Color.white)
+                .ignoresSafeArea()
+                .toolbar(.hidden, for: .tabBar)
+                .toastView(toast: $toast)
+                .onChange(of: reviewText) { _, newValue in
+                    guard newValue.count > maxReviewLength else { return }
+                    reviewText = String(newValue.prefix(maxReviewLength))
+                }
+                .onChange(of: isReviewFieldFocused) { _, isFocused in
+                    guard isFocused else { return }
+                    scrollToEditor(using: proxy)
+                }
+                .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
+                    updateKeyboardHeight(with: notification, safeAreaBottom: geometry.safeAreaInsets.bottom)
+                    guard isReviewFieldFocused else { return }
+                    scrollToEditor(using: proxy)
+                }
+                .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+                    keyboardHeight = 0
+                }
+                .task(id: place.keyword) {
+                    loadSavedCompletion()
+                }
             }
         }
     }
@@ -225,6 +248,22 @@ struct StampDetailView: View {
             UIImage(data: photo.imageData)
         }
         hasCompletedRecord = true
+    }
+
+    private func scrollToEditor(using proxy: ScrollViewProxy) {
+        withAnimation(.easeInOut(duration: 0.25)) {
+            proxy.scrollTo(actionButtonID, anchor: .bottom)
+        }
+    }
+
+    private func updateKeyboardHeight(with notification: Notification, safeAreaBottom: CGFloat) {
+        guard
+            let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect
+        else {
+            return
+        }
+
+        keyboardHeight = max(0, keyboardFrame.height - safeAreaBottom)
     }
 
     @ViewBuilder

--- a/Pollector/View/StampDetailView.swift
+++ b/Pollector/View/StampDetailView.swift
@@ -182,7 +182,7 @@ struct StampDetailView: View {
             }
 
             return PlaceImageItem(
-                id: "\(photo.sortIndex)-\(photo.reference)",
+                id: "\(photo.sortIndexValue)-\(photo.reference)",
                 image: image
             )
         }

--- a/Pollector/View/StampDetailView.swift
+++ b/Pollector/View/StampDetailView.swift
@@ -11,6 +11,7 @@ import SwiftData
 
 struct StampDetailView: View {
     let place: Places
+    let onSaved: () -> Void
 
     @Environment(\.modelContext) private var modelContext
     @State private var toast: FancyToast? = nil
@@ -22,8 +23,9 @@ struct StampDetailView: View {
     @State private var hasCompletedRecord: Bool
     private let maxReviewLength = 500
 
-    init(place: Places, isCompleted: Bool) {
+    init(place: Places, isCompleted: Bool, onSaved: @escaping () -> Void = {}) {
         self.place = place
+        self.onSaved = onSaved
         _hasCompletedRecord = State(initialValue: isCompleted)
     }
 
@@ -202,7 +204,7 @@ struct StampDetailView: View {
 
         try? modelContext.save()
         hasCompletedRecord = true
-        toast = FancyToast(message: "기록을 저장했어요")
+        onSaved()
         dismiss()
     }
 

--- a/Pollector/View/StampDetailView.swift
+++ b/Pollector/View/StampDetailView.swift
@@ -50,7 +50,7 @@ struct StampDetailView: View {
                     HStack {
                         VStack(spacing: 0) {
                             HStack {
-                                Text("포항에서 둘러보기")
+                                Text(place.address ?? "위치 정보가 없어요")
                                     .font(.body3)
                                     .foregroundStyle(.neutral10)
                                     .padding(.leading, 16)
@@ -73,7 +73,7 @@ struct StampDetailView: View {
                                     }
                                 }
 
-                                Text(place.address ?? "주소 정보 없음")
+                                Text(place.address ?? "위치 정보가 없어요")
                                     .font(.body4)
 
                                 Button {

--- a/Pollector/View/StampDetailView.swift
+++ b/Pollector/View/StampDetailView.swift
@@ -1,6 +1,6 @@
 //
 //  StampDetailView.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 3/29/26.
 //

--- a/Pollector/View/StampDetailView.swift
+++ b/Pollector/View/StampDetailView.swift
@@ -22,15 +22,16 @@ struct StampDetailView: View {
             let contentWidth = max(0, geometry.size.width - 32)
 
             ScrollView {
-                placeImagePager
-                    .frame(height: 240)
-                    .frame(maxWidth: .infinity)
-                    .clipped()
-                    .padding(.top, 10)
-                    .padding(.bottom, 16)
-
-                PageControl(numberOfPages: pageCount, currentPage: $selection)
-                    .padding(.bottom, 16)
+                ZStack(alignment: .bottom) {
+                    placeImagePager
+                        .frame(height: 240)
+                        .frame(maxWidth: .infinity)
+                        .clipped()
+                        .padding(.top, 10)
+                    
+                    PageControl(numberOfPages: pageCount, currentPage: $selection)
+                        .padding(.bottom, 16)
+                }
 
                 VStack(alignment: .leading, spacing: 0) {
                     HStack {
@@ -90,7 +91,7 @@ struct StampDetailView: View {
                             }
                             .foregroundStyle(.neutral5)
                             .padding(.leading, 16)
-                            .padding(.bottom, 30)
+                            .padding(.bottom, 48)
                         }
                     }
 

--- a/Pollector/View/StampDetailView.swift
+++ b/Pollector/View/StampDetailView.swift
@@ -115,7 +115,7 @@ struct StampDetailView: View {
                 .padding(.horizontal, 16)
 
                 ActionButton(
-                    title: isCompleted ? "기록 완료" : "기록 남기기",
+                    title: hasCompletedRecord ? "기록 완료" : "기록 남기기",
                     imageName: "pencil",
                     backgroundColor: hasCompletedRecord ? Color.gray8 : Color.neutral4,
                     isDisabled: hasCompletedRecord

--- a/Pollector/View/StampDetailView.swift
+++ b/Pollector/View/StampDetailView.swift
@@ -20,6 +20,7 @@ struct StampDetailView: View {
     @State private var selection = 0
     @State private var selectedImages: [UIImage] = []
     @State private var hasCompletedRecord: Bool
+    private let maxReviewLength = 500
 
     init(place: Places, isCompleted: Bool) {
         self.place = place
@@ -92,17 +93,26 @@ struct StampDetailView: View {
                             .font(.micro1)
                             .foregroundStyle(.gray5)
                             .padding(.bottom, 8)
-
-                        Text(Date().koreanDateString)
-                            .font(.body4)
-                            .foregroundStyle(.neutral10)
-                            .padding(.bottom, 8)
-
+                        
                         ImagePickerView(
                             width: contentWidth,
                             selectedImages: $selectedImages,
                             isLocked: hasCompletedRecord
                         )
+                        .padding(.bottom, 8)
+                        
+                        HStack {
+                            Text("\(Date().koreanDateString)에 방문")
+                                .foregroundStyle(.neutral10)
+                            
+                            Spacer()
+                            
+                            Text("\(reviewText.count) / \(maxReviewLength)")
+                                .foregroundStyle(.neutral7)
+                        }
+                        .font(.body4)
+                        .padding(.horizontal, 6)
+                        .padding(.bottom, 8)
                     }
                     .padding(.horizontal, 16)
                 }
@@ -113,6 +123,7 @@ struct StampDetailView: View {
                     isDisabled: hasCompletedRecord
                 )
                 .padding(.horizontal, 16)
+                .padding(.bottom, 24)
 
                 ActionButton(
                     title: hasCompletedRecord ? "기록 완료" : "기록 남기기",
@@ -122,7 +133,6 @@ struct StampDetailView: View {
                 ) {
                     stampButtonTapped()
                 }
-                .padding(.top, 24)
                 .padding(.horizontal, 24)
                 .padding(.bottom, 32)
             }
@@ -130,6 +140,10 @@ struct StampDetailView: View {
             .ignoresSafeArea()
             .toolbar(.hidden, for: .tabBar)
             .toastView(toast: $toast)
+            .onChange(of: reviewText) { _, newValue in
+                guard newValue.count > maxReviewLength else { return }
+                reviewText = String(newValue.prefix(maxReviewLength))
+            }
             .task(id: place.keyword) {
                 loadSavedCompletion()
             }
@@ -204,7 +218,7 @@ struct StampDetailView: View {
             return
         }
 
-        reviewText = completion.reviewText ?? ""
+        reviewText = String((completion.reviewText ?? "").prefix(maxReviewLength))
         selectedImages = completion.sortedPhotos.compactMap { photo in
             UIImage(data: photo.imageData)
         }

--- a/Pollector/View/StampDetailView.swift
+++ b/Pollector/View/StampDetailView.swift
@@ -15,7 +15,6 @@ struct StampDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var reviewText = ""
     @State private var selection = 0
-    @State private var isBookmarked = false
 
     var body: some View {
         GeometryReader { geometry in
@@ -44,55 +43,33 @@ struct StampDetailView: View {
                     }
                     .padding(.leading, 16)
                     .padding(.bottom, 8)
+                    
+                    VStack(spacing: 0) {
+                        HStack {
+                            Text(place.address ?? "위치 정보가 없어요")
+                                .font(.body4)
+                                .foregroundStyle(.neutral10)
 
-                    HStack {
-                        VStack(spacing: 0) {
-                            HStack {
-                                Text(place.address ?? "위치 정보가 없어요")
-                                    .font(.body3)
-                                    .foregroundStyle(.neutral10)
-                                    .padding(.leading, 16)
-                                    .padding(.bottom, 8)
-
-                                Spacer()
-                            }
-
-                            HStack {
-                                Button {
-                                    print("바로가기 클릭")
-                                } label: {
-                                    HStack(spacing: 4) {
-                                        Image(systemName: "pin.fill")
-                                            .font(.body4)
-                                            .frame(width: 13, height: 13)
-
-                                        Text("바로가기")
-                                            .font(.body4)
+                            Button {
+                                if let address = place.address {
+                                    UIPasteboard.general.string = address
+                                }
+                            } label: {
+                                Text("복사")
+                                    .font(.micro2)
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 4)
+                                    .foregroundStyle(.neutral5)
+                                    .background {
+                                        RoundedRectangle(cornerRadius: 16)
+                                            .fill(Color.gray2)
                                     }
-                                }
-
-                                Text(place.address ?? "위치 정보가 없어요")
-                                    .font(.body4)
-
-                                Button {
-                                    print("복사")
-                                } label: {
-                                    Text("복사")
-                                        .font(.micro2)
-                                        .padding(.horizontal, 8)
-                                        .padding(.vertical, 4)
-                                        .background {
-                                            RoundedRectangle(cornerRadius: 16)
-                                                .fill(Color.gray2)
-                                        }
-                                }
-
-                                Spacer()
                             }
-                            .foregroundStyle(.neutral5)
-                            .padding(.leading, 16)
-                            .padding(.bottom, 48)
+
+                            Spacer()
                         }
+                        .padding(.leading, 16)
+                        .padding(.bottom, 48)
                     }
 
                     VStack(alignment: .leading, spacing: 0) {

--- a/Pollector/View/StampDetailView.swift
+++ b/Pollector/View/StampDetailView.swift
@@ -11,6 +11,7 @@ import UIKit
 struct StampDetailView: View {
     let place: Places
     let onStampCompleted: () -> Void
+    @State private var toast: FancyToast? = nil
 
     @Environment(\.dismiss) private var dismiss
     @State private var reviewText = ""
@@ -54,6 +55,7 @@ struct StampDetailView: View {
                                 if let address = place.address {
                                     UIPasteboard.general.string = address
                                 }
+                                toast = FancyToast(message: "주소를 복사했어요")
                             } label: {
                                 Text("복사")
                                     .font(.micro2)
@@ -111,6 +113,7 @@ struct StampDetailView: View {
             }
             .background(Color.white)
             .toolbar(.hidden, for: .tabBar)
+            .toastView(toast: $toast)
         }
     }
 

--- a/Pollector/ViewModel/SearchViewModel.swift
+++ b/Pollector/ViewModel/SearchViewModel.swift
@@ -1,6 +1,6 @@
 //
 //  SearchViewModel.swift
-//  pohangBuddy
+//  Pollector
 //
 //  Created by 이은지 on 4/21/26.
 //

--- a/Pollector/ViewModel/SearchViewModel.swift
+++ b/Pollector/ViewModel/SearchViewModel.swift
@@ -20,6 +20,7 @@ final class SearchViewModel: ObservableObject {
     @Published var errorMessage: String?
 
     private let service: PlacesServicing
+    private let maxCachedPhotoCount = 3
 
     init(service: PlacesServicing) {
         self.service = service
@@ -41,9 +42,7 @@ final class SearchViewModel: ObservableObject {
     }
 
     func loadPlaces(for keywords: [String], modelContext: ModelContext) async {
-        places = keywords.map { keyword in
-            makePlaceholderPlace(keyword: keyword)
-        }
+        places = []
 
         var updatedPlaces: [Places] = []
         var latestErrorMessage: String?
@@ -79,28 +78,36 @@ final class SearchViewModel: ObservableObject {
                 let places = try await service.searchByText(keyword: keyword)
 
                 guard let place = places.first else {
-                    updatedPlaces.append(makePlaceholderPlace(keyword: keyword))
                     continue
                 }
 
-                let photoImageDataList = await fetchPhotoDataList(from: place)
                 let cachedPlace = makeCachedPlace(
                     from: place,
                     keyword: keyword,
                     cacheKey: cacheKey,
-                    photoImageDataList: photoImageDataList
+                    photos: []
                 )
 
                 modelContext.insert(cachedPlace)
-                try? modelContext.save()
+                do {
+                    try modelContext.save()
+                    let photoImageDataList = await fetchPhotoDataList(from: place)
+                    replacePhotos(
+                        on: cachedPlace,
+                        with: makePlacesPhotos(from: place, photoImageDataList: photoImageDataList),
+                        modelContext: modelContext
+                    )
+                    try modelContext.save()
+                    logCacheSaved(keyword: keyword)
+                } catch {
+                    logCacheSaveFailure(keyword: keyword, error: error)
+                }
 
                 updatedPlaces.append(cachedPlace)
             } catch let error as NetworkError {
                 latestErrorMessage = error.localizedDescription
-                updatedPlaces.append(makePlaceholderPlace(keyword: keyword))
             } catch {
                 latestErrorMessage = NetworkError.unknownError.localizedDescription
-                updatedPlaces.append(makePlaceholderPlace(keyword: keyword))
             }
         }
 
@@ -109,11 +116,12 @@ final class SearchViewModel: ObservableObject {
     }
 
     private func makeCacheKey(keyword: String) -> String {
-        "pohang:\(keyword)"
+        let normalizedKeyword = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
+        return "pohang:\(normalizedKeyword)"
     }
 
     private func fetchCachedPlace(cacheKey: String, modelContext: ModelContext) -> Places? {
-        let descriptor = FetchDescriptor<Places>(
+        var descriptor = FetchDescriptor<Places>(
             predicate: #Predicate { place in
                 place.cacheKey == cacheKey
             },
@@ -121,15 +129,42 @@ final class SearchViewModel: ObservableObject {
                 SortDescriptor(\.createdDate, order: .reverse)
             ]
         )
+        descriptor.fetchLimit = 1
 
-        return try? modelContext.fetch(descriptor).first
+        do {
+            if let cachedPlace = try modelContext.fetch(descriptor).first {
+                return cachedPlace
+            }
+
+            return fetchCachedPlaceByScanning(cacheKey: cacheKey, modelContext: modelContext)
+        } catch {
+            logCacheFetchFailure(cacheKey: cacheKey, error: error)
+            return fetchCachedPlaceByScanning(cacheKey: cacheKey, modelContext: modelContext)
+        }
+    }
+
+    private func fetchCachedPlaceByScanning(cacheKey: String, modelContext: ModelContext) -> Places? {
+        let descriptor = FetchDescriptor<Places>(
+            sortBy: [
+                SortDescriptor(\.createdDate, order: .reverse)
+            ]
+        )
+
+        do {
+            let cachedPlaces = try modelContext.fetch(descriptor)
+            logCacheSnapshot(cacheKey: cacheKey, cachedPlaces: cachedPlaces)
+            return cachedPlaces.first { $0.cacheKey == cacheKey }
+        } catch {
+            logCacheFetchFailure(cacheKey: cacheKey, error: error)
+            return nil
+        }
     }
 
     private func makeCachedPlace(
         from place: Place,
         keyword: String,
         cacheKey: String,
-        photoImageDataList: [Data?]
+        photos: [PlacesPhoto]
     ) -> Places {
         return Places(
             cacheKey: cacheKey,
@@ -141,15 +176,7 @@ final class SearchViewModel: ObservableObject {
             longitude: place.location.longitude,
             googleMapsURL: nil,
             rating: place.rating.map(Double.init),
-            photos: makePlacesPhotos(from: place, photoImageDataList: photoImageDataList)
-        )
-    }
-
-    private func makePlaceholderPlace(keyword: String) -> Places {
-        Places(
-            cacheKey: makeCacheKey(keyword: keyword),
-            keyword: keyword,
-            name: keyword
+            photos: photos
         )
     }
 
@@ -185,12 +212,18 @@ final class SearchViewModel: ObservableObject {
         cachedPlace.latitude = place.location.latitude
         cachedPlace.longitude = place.location.longitude
         cachedPlace.rating = place.rating.map(Double.init)
-        cachedPlace.photos = makePlacesPhotos(
-            from: place,
-            photoImageDataList: photoImageDataList
+        replacePhotos(
+            on: cachedPlace,
+            with: makePlacesPhotos(from: place, photoImageDataList: photoImageDataList),
+            modelContext: modelContext
         )
 
-        try? modelContext.save()
+        do {
+            try modelContext.save()
+            logCacheSaved(keyword: keyword)
+        } catch {
+            logCacheSaveFailure(keyword: keyword, error: error)
+        }
     }
 
     private func fetchPhotoDataList(from place: Place) async -> [Data?] {
@@ -200,7 +233,7 @@ final class SearchViewModel: ObservableObject {
 
         var photoDataList: [Data?] = []
 
-        for photo in photos {
+        for photo in photos.prefix(maxCachedPhotoCount) {
             do {
                 let image = try await service.fetchPhoto(
                     photo,
@@ -217,7 +250,7 @@ final class SearchViewModel: ObservableObject {
     }
 
     private func makePlacesPhotos(from place: Place, photoImageDataList: [Data?]) -> [PlacesPhoto] {
-        place.photos?.enumerated().map { index, photo in
+        place.photos?.prefix(maxCachedPhotoCount).enumerated().map { index, photo in
             PlacesPhoto(
                 reference: photo.description,
                 width: Int(photo.maxSize.width),
@@ -226,6 +259,22 @@ final class SearchViewModel: ObservableObject {
                 sortIndex: index
             )
         } ?? []
+    }
+
+    private func replacePhotos(
+        on cachedPlace: Places,
+        with photos: [PlacesPhoto],
+        modelContext: ModelContext
+    ) {
+        cachedPlace.photos.forEach { photo in
+            modelContext.delete(photo)
+        }
+
+        photos.forEach { photo in
+            modelContext.insert(photo)
+        }
+
+        cachedPlace.photos = photos
     }
 
     private func logCacheHit(keyword: String) {
@@ -237,6 +286,35 @@ final class SearchViewModel: ObservableObject {
     private func logCacheMiss(keyword: String) {
         #if DEBUG
         print("🌐 [PlacesCache] miss: \(keyword)")
+        #endif
+    }
+
+    private func logCacheSaved(keyword: String) {
+        #if DEBUG
+        print("✅ [PlacesCache] saved: \(keyword)")
+        #endif
+    }
+
+    private func logCacheFetchFailure(cacheKey: String, error: Error) {
+        #if DEBUG
+        print("⚠️ [PlacesCache] fetch failed: \(cacheKey) | \(error)")
+        #endif
+    }
+
+    private func logCacheSaveFailure(keyword: String, error: Error) {
+        #if DEBUG
+        print("⚠️ [PlacesCache] save failed: \(keyword) | \(error)")
+        #endif
+    }
+
+    private func logCacheSnapshot(cacheKey: String, cachedPlaces: [Places]) {
+        #if DEBUG
+        let cacheKeys = cachedPlaces
+            .prefix(8)
+            .map(\.cacheKey)
+            .joined(separator: ", ")
+
+        print("🧾 [PlacesCache] lookup: \(cacheKey) | stored count: \(cachedPlaces.count) | keys: [\(cacheKeys)]")
         #endif
     }
 }

--- a/Pollector/ViewModel/SearchViewModel.swift
+++ b/Pollector/ViewModel/SearchViewModel.swift
@@ -53,7 +53,7 @@ final class SearchViewModel: ObservableObject {
 
             if let cachedPlace = fetchCachedPlace(cacheKey: cacheKey, modelContext: modelContext) {
                 logCacheHit(keyword: keyword)
-                if hasRenderablePhoto(cachedPlace) {
+                if !needsPhotoRefresh(cachedPlace) {
                     updatedPlaces.append(cachedPlace)
                     continue
                 }
@@ -83,12 +83,12 @@ final class SearchViewModel: ObservableObject {
                     continue
                 }
 
-                let photoImageData = await fetchFirstPhotoData(from: place)
+                let photoImageDataList = await fetchPhotoDataList(from: place)
                 let cachedPlace = makeCachedPlace(
                     from: place,
                     keyword: keyword,
                     cacheKey: cacheKey,
-                    photoImageData: photoImageData
+                    photoImageDataList: photoImageDataList
                 )
 
                 modelContext.insert(cachedPlace)
@@ -129,7 +129,7 @@ final class SearchViewModel: ObservableObject {
         from place: Place,
         keyword: String,
         cacheKey: String,
-        photoImageData: Data?
+        photoImageDataList: [Data?]
     ) -> Places {
         return Places(
             cacheKey: cacheKey,
@@ -141,7 +141,7 @@ final class SearchViewModel: ObservableObject {
             longitude: place.location.longitude,
             googleMapsURL: nil,
             rating: place.rating.map(Double.init),
-            photos: makePlacesPhotos(from: place, photoImageData: photoImageData)
+            photos: makePlacesPhotos(from: place, photoImageDataList: photoImageDataList)
         )
     }
 
@@ -153,12 +153,18 @@ final class SearchViewModel: ObservableObject {
         )
     }
 
-    private func hasRenderablePhoto(_ place: Places) -> Bool {
-        guard let imageData = place.primaryPhoto?.imageData else {
-            return false
+    private func needsPhotoRefresh(_ place: Places) -> Bool {
+        guard !place.photos.isEmpty else {
+            return true
         }
 
-        return !imageData.isEmpty && UIImage(data: imageData) != nil
+        return place.photos.contains { photo in
+            guard let imageData = photo.imageData else {
+                return true
+            }
+
+            return imageData.isEmpty || UIImage(data: imageData) == nil
+        }
     }
 
     private func refreshCachedPlace(
@@ -172,7 +178,7 @@ final class SearchViewModel: ObservableObject {
             return
         }
 
-        let photoImageData = await fetchFirstPhotoData(from: place)
+        let photoImageDataList = await fetchPhotoDataList(from: place)
         cachedPlace.placeID = place.placeID
         cachedPlace.name = place.displayName ?? keyword
         cachedPlace.address = place.formattedAddress
@@ -181,36 +187,43 @@ final class SearchViewModel: ObservableObject {
         cachedPlace.rating = place.rating.map(Double.init)
         cachedPlace.photos = makePlacesPhotos(
             from: place,
-            photoImageData: photoImageData
+            photoImageDataList: photoImageDataList
         )
 
         try? modelContext.save()
     }
 
-    private func fetchFirstPhotoData(from place: Place) async -> Data? {
-        guard let photo = place.photos?.first else {
-            return nil
+    private func fetchPhotoDataList(from place: Place) async -> [Data?] {
+        guard let photos = place.photos else {
+            return []
         }
 
-        do {
-            let image = try await service.fetchPhoto(
-                photo,
-                maxSize: CGSize(width: 600, height: 700)
-            )
+        var photoDataList: [Data?] = []
 
-            return image.jpegData(compressionQuality: 0.85)
-        } catch {
-            return nil
+        for photo in photos {
+            do {
+                let image = try await service.fetchPhoto(
+                    photo,
+                    maxSize: CGSize(width: 600, height: 700)
+                )
+
+                photoDataList.append(image.jpegData(compressionQuality: 0.85))
+            } catch {
+                photoDataList.append(nil)
+            }
         }
+
+        return photoDataList
     }
 
-    private func makePlacesPhotos(from place: Place, photoImageData: Data?) -> [PlacesPhoto] {
+    private func makePlacesPhotos(from place: Place, photoImageDataList: [Data?]) -> [PlacesPhoto] {
         place.photos?.enumerated().map { index, photo in
             PlacesPhoto(
                 reference: photo.description,
                 width: Int(photo.maxSize.width),
                 height: Int(photo.maxSize.height),
-                imageData: index == 0 ? photoImageData : nil
+                imageData: photoImageDataList.indices.contains(index) ? photoImageDataList[index] : nil,
+                sortIndex: index
             )
         } ?? []
     }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- ex) Closes #13 -->
Closes #24 

---

## 🌿 작업 브랜치
<!-- ex) feat/launch-screen -->
- `feat/stamp-detail-view`

---

## ⚠️ 발생한 이슈
<!-- 작업하면서 겪은 문제나 고민 -->
- ViewModifier에 대한 고찰

---

## 📚 배운 점
<!-- 이번 PR에서 얻은 인사이트 -->
- 복사 기능 구현
- 페이지 컨트롤
- SwiftUI에서의 PhotoPicker


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 토스트 알림 시스템 추가로 사용자 피드백 개선
  * 기록 작성 시 여러 사진 선택 및 저장 기능 추가
  * 작성한 기록의 로컬 저장소 지원

* **개선사항**
  * 버튼 및 텍스트 입력 필드에 비활성화 상태 추가
  * 페이지 컨트롤 색상 스타일 개선
  * 기록 작성 워크플로우 향상

* **기타**
  * 앱 브랜딩 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->